### PR TITLE
fix: remove gitea container at end of tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1052,7 @@ dependencies = [
  "base64 0.22.1",
  "clap",
  "console",
+ "ctor",
  "expanduser",
  "fs_extra",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ reqwest = { version = "0.12.12", features = ["blocking", "brotli", "json"] }
 ssh-key = { version = "0.6.7", features = ["ed25519"] }
 rand = "0.8.5"
 base64 = "0.22.1"
+ctor = "0.2.9"
 
 [target."cfg(unix)".dependencies]
 expanduser = "1.2.2"

--- a/tests/container/gitea.rs
+++ b/tests/container/gitea.rs
@@ -23,7 +23,6 @@ pub struct GiteaContainer {
     pub private_key: String,
     token: String,
     tls_cert: String,
-    // tmp_dir: TempDir,
     http_client: Client,
 }
 

--- a/tests/gitea_tests.rs
+++ b/tests/gitea_tests.rs
@@ -18,6 +18,18 @@ pub fn gitea_container() -> &'static GiteaContainer {
     GITEA_CONTAINER.get_or_init(GiteaContainer::start)
 }
 
+// Remove gitea container at end of tests
+// Comment out this function for debugging to keep container running after tests
+#[ctor::dtor]
+fn cleanup() {
+    let container = &GITEA_CONTAINER as *const _ as *mut OnceLock<GiteaContainer>;
+    // Safety: We have exclusive access to GITEA_CONTAINER during cleanup/destruction
+    if let Some(container) = unsafe { (*container).take() } {
+        println!("Remove Gitea container...\n");
+        drop(container);
+    }
+}
+
 fn update_command(workspace_path: &Path) {
     lock(workspace_path).unwrap();
     update(workspace_path, 8).unwrap();


### PR DESCRIPTION
Context:
* after running cargo test, gitea container is still started

Problem:
* we want container to be destroyed at end of tests
* `cargo test` command doesn't cleanup static variables

Solution:
* use ctor crate as workaround to drop gitea container