### PR TITLE
fix: add removed --version cli option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use git_workspace::utils::{ensure_workspace_dir_exists, expand_workspace_path};
 use std::path::PathBuf;
 
 #[derive(clap::Parser)]
-#[command(name = "git-workspace", author, about)]
+#[command(name = "git-workspace", author, about, version)]
 struct Args {
     #[arg(short = 'w', long = "workspace", env = "GIT_WORKSPACE")]
     workspace: PathBuf,


### PR DESCRIPTION
Context:
* since version 1.8.0, git-workspace --version is not working, see:
  - https://github.com/orf/git-workspace/commit/59df413d3cd16c7849a024ef2b8de3fd1ff2b337

Solution:
* use clap parameter to add --version cli option