### PR TITLE
ci: add code coverage job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,10 @@
 on:
   workflow_dispatch:
-
   push:
     tags:
-      - 'v*'
+      - "v*"
     branches:
-      - '**'
+      - "**"
 
 name: CI
 
@@ -16,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
             bin: git-workspace
@@ -38,6 +37,9 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       release_profile: "release"
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.7
 
@@ -47,7 +49,6 @@ jobs:
           mkdir -p "$RUNNER_TEMP/workspace-test-dir/"
           echo GIT_WORKSPACE=$RUNNER_TEMP/workspace-test-dir/ >> $GITHUB_ENV
 
-      - uses: actions/checkout@master
       - name: Switch SSH to https
         shell: bash
         run: |
@@ -59,14 +60,10 @@ jobs:
             git config --global credential.helper wincred
           fi
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.7
-
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache-on-failure: 'false'
-
-      - run: cargo build
+          cache-on-failure: "false"
 
       - name: git workspace add github org
         run: cargo run -- add github django --exclude "/django.*" --env-name GITHUB_ALTERNATIVE_TOKEN
@@ -90,6 +87,7 @@ jobs:
       - name: Build release
         if: startsWith(github.ref, 'refs/tags/') || inputs.publish-tag
         run: cargo build --profile=${{env.release_profile}}
+
       - name: Package
         if: startsWith(github.ref, 'refs/tags/') || inputs.publish-tag
         shell: bash
@@ -103,6 +101,7 @@ jobs:
           tar czvf ../../${{ matrix.name }} ${{ matrix.bin }}
           fi
           cd -
+
       - name: Archive binaries
         uses: actions/upload-artifact@v4
         if: startsWith(github.ref, 'refs/tags/') || inputs.publish-tag
@@ -126,9 +125,10 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.7
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache-on-failure: 'false'
+          cache-on-failure: "false"
 
       - name: Run cargo fmt
         if: success() || failure()
@@ -138,6 +138,46 @@ jobs:
         if: success() || failure()
         run: cargo check
 
-      - if: success() || failure()
+      - name: Run cargo clippy
+        if: success() || failure()
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  coverage:
+    name: Tests with coverage
+    runs-on: ubuntu-latest
+    env:
+      RUST_BACKTRACE: "1"
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-on-failure: "false"
+          components: llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate LLVM coverage report
+        run: cargo llvm-cov --all-features --workspace --codecov --output-path codecov.json
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: codecov.json
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 example_workspace/*
 !example_workspace/*.toml
 !example_workspace/.gitkeep
+
+# Code coverage
+codecov.json

--- a/README.md
+++ b/README.md
@@ -246,4 +246,12 @@ Consider using [shfmt](https://github.com/patrickvane/shfmt) to optimize the fil
 
 This is my first 'proper' Rust project. If you're experienced with Rust you might puke at the code, but any feedback to help me improve would be greatly appreciated!
 
-If you want to contribute then just go for it. `cargo install` should get you ready to go. Be warned: there are currently no tests :bomb:. I run integration tests with Github Actions, but that's about it. It's on my to-do list, I promise :tm:.
+If you want to contribute then just go for it. `cargo install` should get you ready to go.
+
+To run the test suite:
+
+- Run unit tests with `cargo test --lib`
+- Run integration tests with `cargo test --test '*'` 
+- Run both unit and integration tests with `cargo test`
+
+Test coverage reports are automatically generated and uploaded to Codecov for all pull requests.

--- a/tests/container/gitea.rs
+++ b/tests/container/gitea.rs
@@ -69,16 +69,16 @@ impl GiteaCommit {
 impl GiteaContainer {
     fn generate_test_ssh_key() -> (String, String) {
         let private_key = PrivateKey::random(&mut rand::thread_rng(), Ed25519)
-            .unwrap_or_else(|_| panic!("Failed to generate key"));
+            .unwrap_or_else(|e| panic!("Failed to generate key: {}", e));
         let public_key = private_key.public_key();
 
         // Convert to OpenSSH format strings
         let private_key_str = private_key
             .to_openssh(LineEnding::LF)
-            .unwrap_or_else(|_| panic!("Failed to serialize private key"));
+            .unwrap_or_else(|e| panic!("Failed to serialize private key: {}", e));
         let public_key_str = public_key
             .to_openssh()
-            .unwrap_or_else(|_| panic!("Failed to serialize public key"));
+            .unwrap_or_else(|e| panic!("Failed to serialize public key: {}", e));
 
         (private_key_str.to_string(), public_key_str.to_string())
     }
@@ -103,7 +103,7 @@ impl GiteaContainer {
             .with_mapped_port(443, GITEA_HTTP_PORT)
             .with_mapped_port(22, GITEA_SSH_PORT)
             .start()
-            .unwrap_or_else(|_| panic!("to start the container"));
+            .unwrap_or_else(|e| panic!("Failed to start Gitea container: {}", e));
         let url = "https://localhost".to_string();
 
         // Generate token
@@ -122,7 +122,7 @@ impl GiteaContainer {
         let mut token = String::new();
         gitea
             .exec(command)
-            .unwrap_or_else(|_| panic!("to generate access token"))
+            .unwrap_or_else(|e| panic!("to generate access token: {}", e))
             .stdout()
             .read_to_string(&mut token)
             .unwrap();
@@ -196,9 +196,9 @@ impl GiteaContainer {
                 username: org.to_string(),
             })
             .send()
-            .unwrap_or_else(|_| panic!("expect to add org {}", org))
+            .unwrap_or_else(|e| panic!("expect to add org {}: {}", org, e))
             .error_for_status()
-            .unwrap_or_else(|_| panic!("expect 2xx http response for creating {} org", org));
+            .unwrap_or_else(|e| panic!("expect 2xx http response for creating {} org: {}", org, e));
     }
 
     /// Sets up the test environment for Gitea integration tests
@@ -270,12 +270,13 @@ impl GiteaContainer {
                     name: repo.as_ref().to_string(),
                 })
                 .send()
-                .unwrap_or_else(|_| panic!("expect to add repo {}", repo.as_ref()))
+                .unwrap_or_else(|e| panic!("expect to add repo {}: {}", repo.as_ref(), e))
                 .error_for_status()
-                .unwrap_or_else(|_| {
+                .unwrap_or_else(|e| {
                     panic!(
-                        "expect 2xx http response for creating {} repo",
-                        repo.as_ref()
+                        "expect 2xx http response for creating {} repo: {}",
+                        repo.as_ref(),
+                        e,
                     )
                 });
         }
@@ -293,12 +294,13 @@ impl GiteaContainer {
                 .delete(&url)
                 .bearer_auth(&self.token)
                 .send()
-                .unwrap_or_else(|_| panic!("expect to delete repo {}", repo.as_ref()))
+                .unwrap_or_else(|e| panic!("expect to delete repo {}: {}", repo.as_ref(), e))
                 .error_for_status()
-                .unwrap_or_else(|_| {
+                .unwrap_or_else(|e| {
                     panic!(
-                        "expect 2xx http response for deleting {} repo",
-                        repo.as_ref()
+                        "expect 2xx http response for deleting {} repo: {}",
+                        repo.as_ref(),
+                        e,
                     )
                 });
         }
@@ -315,12 +317,12 @@ impl GiteaContainer {
             .bearer_auth(&self.token)
             .json(body)
             .send()
-            .unwrap_or_else(|_| panic!("expect to create new commit for repo {}", repo))
+            .unwrap_or_else(|e| panic!("expect to create new commit for repo {}: {}", repo, e))
             .error_for_status()
-            .unwrap_or_else(|_| {
+            .unwrap_or_else(|e| {
                 panic!(
-                    "expect 2xx http response when creating new commit on {} repo",
-                    repo
+                    "expect 2xx http response when creating new commit on {} repo: {}",
+                    repo, e,
                 )
             });
     }

--- a/tests/container/gitea.rs
+++ b/tests/container/gitea.rs
@@ -97,11 +97,16 @@ impl GiteaContainer {
     pub fn start() -> Self {
         let (private_key, public_key) = Self::generate_test_ssh_key();
         let (username, password) = ("42".to_string(), "42".to_string());
+        let ssh_port = if std::env::var("CI").is_ok() {
+            2222
+        } else {
+            22
+        };
         let gitea = Gitea::default()
             .with_admin_account(&username, &password, Some(public_key))
             .with_tls(true)
             .with_mapped_port(443, GITEA_HTTP_PORT)
-            .with_mapped_port(22, GITEA_SSH_PORT)
+            .with_mapped_port(ssh_port, GITEA_SSH_PORT)
             .start()
             .unwrap_or_else(|e| panic!("Failed to start Gitea container: {}", e));
         let url = "https://localhost".to_string();


### PR DESCRIPTION
Hello @orf :)

Context:
* unit and integration tests are done

Problem:
* no ci to launch this tests and see coverage progress

Solution:
* use Codecov to upload code coverage generated with llvm-cov, see:
  - https://github.com/taiki-e/cargo-llvm-cov?tab=readme-ov-file#github-actions-and-codecov
  
Integration to Codecov:
  - [Create an account](https://about.codecov.io/sign-up/)
  - Get [`CODECOV_TOKEN` value](https://app.codecov.io/gh/orf/git-workspace/config/general)
  - Create `CODECOV_TOKEN`  repository secret [here](https://github.com/orf/git-workspace/settings/secrets/actions)
  
  You can also [add a coverage badge](https://app.codecov.io/gh/orf/git-workspace/config/badge) in README.md similar to:
  [![codecov](https://codecov.io/gh/jagu-sayan/git-workspace/branch/ci%2Fadd-code-coverage/graph/badge.svg?token=3URHJJ1FZG)](https://codecov.io/gh/jagu-sayan/git-workspace)