### PR TITLE
feat: add command for shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5c5508ea23c5366f77e53f5a0070e5a84e51687ec3ef9e0464c86dc8d13ce98"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,6 +1060,7 @@ dependencies = [
  "atomic-counter",
  "base64 0.22.1",
  "clap",
+ "clap_complete",
  "console",
  "ctor",
  "expanduser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ globset = "0.4.15"
 git2 = { version = "0.20.0" }
 regex = "1.11.1"
 clap = { version = "4.5.27", features = ["derive", "env"] }
+clap_complete = "4.5.46"
 
 [dev-dependencies]
 rstest = "0.24.0"

--- a/src/commands/completion.rs
+++ b/src/commands/completion.rs
@@ -1,0 +1,10 @@
+use std::io;
+
+use clap::Command;
+use clap_complete::{generate, Shell};
+
+/// Generate shell completions
+pub fn completion(shell: Shell, app: &mut Command) -> anyhow::Result<()> {
+    generate(shell, app, app.get_name().to_string(), &mut io::stdout());
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod add_provider;
 pub mod archive;
+pub mod completion;
 pub mod fetch;
 pub mod list;
 pub mod lock;
@@ -9,6 +10,7 @@ pub mod update;
 
 pub use add_provider::add_provider_to_config;
 pub use archive::archive;
+pub use completion::completion;
 pub use fetch::fetch;
 pub use list::list;
 pub use lock::lock;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
-use clap::Parser;
+use clap::{CommandFactory, Parser, ValueHint};
 use git_workspace::commands::{
-    add_provider_to_config, archive, execute_cmd, fetch, list, lock, pull_all_repositories, update,
+    add_provider_to_config, archive, completion, execute_cmd, fetch, list, lock,
+    pull_all_repositories, update,
 };
 use git_workspace::config::ProviderSource;
 use git_workspace::utils::{ensure_workspace_dir_exists, expand_workspace_path};
@@ -67,6 +68,11 @@ enum Command {
         #[command(subcommand)]
         command: ProviderSource,
     },
+    /// Generate shell completions
+    Completion {
+        /// The shell to generate the completion script for
+        shell: clap_complete::Shell,
+    },
 }
 
 fn main() -> anyhow::Result<()> {
@@ -98,6 +104,7 @@ fn handle_main(args: Args) -> anyhow::Result<()> {
             args,
         } => execute_cmd(&workspace_path, threads, command, args)?,
         Command::SwitchAndPull { threads } => pull_all_repositories(&workspace_path, threads)?,
+        Command::Completion { shell } => completion(shell, &mut Args::command())?,
     };
     Ok(())
 }


### PR DESCRIPTION
Hi, thanks for the project :)

This adds a `git-workspace completion` command to generate shell completions via [clap_complete](https://docs.rs/clap_complete). Quick demo with fish:

```console
$ cargo run completion fish | source
$ complete -C 'git-workspace o'
completion      Generate shell completions
lock    Fetch all repositories from configured providers and write the lockfile
```
